### PR TITLE
Clean up apt cache after installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@
 FROM dockerfile/ubuntu
 
 # Install Python.
-RUN apt-get install -y python python-dev python-pip python-virtualenv
+RUN apt-get update && apt-get install -y \
+    python \
+    python-dev \
+    python-pip \
+    python-virtualenv && \
+  rm -rf /var/lib/apt/lists/*
 
 # Define mountable directories.
 VOLUME ["/data"]


### PR DESCRIPTION
Same as dockerfile/ubuntu#3
This line removes unnecessary ~30MB. See docker-library/buildpack-deps#1
